### PR TITLE
ci: force coloured pytest output

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: ☑ Run unit tests
         run: |
-          python -m pytest -rA tests/unit
+          python -m pytest -rA tests/unit --color=yes
 
   Coverage:
     name: 📈 Collect Coverage Data using Python 3.10
@@ -72,7 +72,7 @@ jobs:
       - name: Collect coverage
         continue-on-error: true
         run: |
-          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit
+          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit --color=yes
 
       - name: Convert to cobertura format
         run: |


### PR DESCRIPTION
GitHub Actions does not provide a TTY to the processes executed on the provided virtual environments (ubuntu or windows). Therefore, CLI tools that detect that to decide whether to use colours do not work properly. See https://github.com/actions/runner/issues/241.

This PR adds argument `--color=yes` to pytest calls in the CI workflow.