### PR TITLE
ci: delay publishing to GitHub Pages until job PublishToGitHubPages

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -7,6 +7,7 @@ defaults:
     shell: bash
 
 jobs:
+
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest
@@ -107,7 +108,7 @@ jobs:
           retention-days: 1
 
   StaticTypeCheck:
-    name: 📈 Check Static Typing using Python 3.10
+    name: 👀 Check Static Typing using Python 3.10
     runs-on: ubuntu-latest
 
     env:
@@ -333,7 +334,7 @@ jobs:
           python3 example.py
 
   BuildTheDocs:
-    name: 📓 Run BuildTheDocs and publish to GH-Pages
+    name: 📓 Run BuildTheDocs
     runs-on: ubuntu-latest
     needs:
       - VerifyDocs
@@ -354,10 +355,10 @@ jobs:
           RUN apk add -U --no-cache graphviz
           EOF
 
-      - name: 🛳️ Build documentation using container edaa/doc and publish to GitHub Pages
+      - name: 🛳️ Build documentation using container edaa/doc
         uses: buildthedocs/btd@v0
         with:
-          token: ${{ github.token }}
+          skip-deploy: true
 
       - name: 📤 Upload 'documentation' artifacts
         uses: actions/upload-artifact@master
@@ -366,27 +367,76 @@ jobs:
           path: doc/_build/html
           retention-days: 7
 
+  PublishToGitHubPages:
+    name: 📚 Publish to GH-Pages
+    runs-on: ubuntu-latest
+    needs:
+      - BuildTheDocs
+      - Coverage
+      - StaticTypeCheck
+
+    env:
+      DOC:      ${{ needs.BuildTheDocs.outputs.artifact }}
+      COVERAGE: ${{ needs.Coverage.outputs.artifact }}
+      TYPING:   ${{ needs.StaticTypeCheck.outputs.artifact }}
+    outputs:
+      artifact: ${{ env.ARTIFACT }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 📥 Download artifacts '${{ env.DOC }}' from 'StaticTypeCheck' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.DOC }}
+          path: public
+
+      - name: 📥 Download artifacts '${{ env.COVERAGE }}' from 'Coverage' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.COVERAGE }}
+          path: public/coverage
+
+      - name: 📥 Download artifacts '${{ env.TYPING }}' from 'StaticTypeCheck' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.TYPING }}
+          path: public/typing
+
+      - name: '📓 Publish site to GitHub Pages'
+        if: github.event_name != 'pull_request'
+        run: |
+          cd public
+          touch .nojekyll
+          git init
+          cp ../.git/config ./.git/config
+          git add .
+          git config --local user.email "BuildTheDocs@GitHubActions"
+          git config --local user.name "GitHub Actions"
+          git commit -a -m "update ${{ github.sha }}"
+          git push -u origin +HEAD:gh-pages
+
   ArtifactCleanUp:
     name: 🗑️ Artifact Cleanup
     runs-on: ubuntu-latest
-
     needs:
-      - Coverage
-      - StaticTypeCheck
       - Package
       - PublishOnPyPI
+      - PublishToGitHubPages
 
     env:
       COVERAGE: ${{ needs.Coverage.outputs.artifact }}
       TYPING:   ${{ needs.StaticTypeCheck.outputs.artifact }}
       PACKAGE:  ${{ needs.Package.outputs.artifact }}
+      DOC:      ${{ needs.BuildTheDocs.outputs.artifact }}
 
     steps:
       - name: 🗑️ Delete all Artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
+            ${{ env.COVERAGE }}
+            ${{ env.TYPING }}
             ${{ env.PACKAGE }}
-
-#            ${{ env.COVERAGE }}
-#            ${{ env.TYPING }}
+            ${{ env.DOC }}


### PR DESCRIPTION
This PR implements some of the tasks listed in #9.

A job named PublishToGitHubPages is added, where docs, coverage and typing artifacts are gathered and pushed to GitHub Pages. At the same time, pushing from job BuildTheDocs is disabled.

By the way, the icon of the static type checking job is changed.