### PR TITLE
tests/requirements: mypy requires lxml

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov>=2.12.1
 
 # Static Type Checking
 mypy>=0.910
+lxml>=4.6.3


### PR DESCRIPTION
In #17, `lxml` was removed from the tests requirements file, but it is needed by `mypy`.