### PR TITLE
ci: rm .gitignore from htmlcov

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Convert to HTML format
         run: |
           coverage html
+          rm htmlcov/.gitignore
 
       - name: 📊 Publish coverage at CodeCov
         continue-on-error: true


### PR DESCRIPTION
Coverage started afding a gitignore file to the html output. See https://coverage.readthedocs.io/en/6.1.1/changes.html?highlight=gitignore#version-6-1-2021-10-30

> Feature: The `html` command writes a `.gitignore` file into the HTML output directory, to prevent the report from being committed to git. If you want to commit it, you will need to delete that file. Closes [issue 1244](https://github.com/nedbat/coveragepy/issues/1244).

This PR removes that `.gitginore` file, so that the content is properly pushed to `gh-pages`.