### PR TITLE
ci: use reusable workflows from pyTooling/Actions

### DIFF
--- a/.btd.yml
+++ b/.btd.yml
@@ -4,6 +4,6 @@ requirements: requirements.txt
 target: gh-pages
 formats: [ html, pdf, man ]
 images:
-  base: edaa/doc
+  base: btdi/sphinx:pytooling
   latex: btdi/latex
 theme: https://codeload.github.com/buildthedocs/sphinx.theme/tar.gz/v1

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -29,45 +29,13 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
-    name: 👀 Check Static Typing using Python 3.10
-    runs-on: ubuntu-latest
-
-    env:
-      PYTHON: "3.10"
-      ARTIFACT: pyEDAA-ProjectModel-typing-html
-    outputs:
-      python: ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🗂 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
-
-      - name: Check Static Typing
-        continue-on-error: true
-        run: |
-          pwd
-          mypy --html-report htmlmypy -m pyEDAA.ProjectModel
-
-      - name: 📤 Upload 'Static Typing Report' artifact
-        continue-on-error: true
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: htmlmypy
-          if-no-files-found: error
-          retention-days: 1
-
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
+    needs:
+      - Params
+    with:
+      package: ${{ fromJson(needs.Params.outputs.params).package }}
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
     name: 📝 Create 'Release Page' on GitHub

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -17,69 +17,16 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
     with:
       TestReport: true
-      
+
   Coverage:
-    name: 📈 Collect Coverage Data using Python 3.10
-    runs-on: ubuntu-latest
-
-    env:
-      PYTHON: "3.10"
-      ARTIFACT: pyEDAA-ProjectModel-coverage-html
-    outputs:
-      python: ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🗂 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
-
-      - name: Collect coverage
-        continue-on-error: true
-        run: |
-          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit --color=yes
-
-      - name: Convert to cobertura format
-        run: |
-          coverage xml
-
-      - name: Convert to HTML format
-        run: |
-          coverage html
-          rm htmlcov/.gitignore
-
-      - name: 📊 Publish coverage at CodeCov
-        continue-on-error: true
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          env_vars: PYTHON
-
-      - name: 📉 Publish coverage at Codacy
-        continue-on-error: true
-        uses: codacy/codacy-coverage-reporter-action@master
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./coverage.xml
-
-      - name: 📤 Upload 'Coverage Report' artifact
-        continue-on-error: true
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: htmlcov
-          if-no-files-found: error
-          retention-days: 1
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    needs:
+      - Params
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+    secrets:
+      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
     name: 👀 Check Static Typing using Python 3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,6 +1,8 @@
 name: Unit Testing, Coverage Collection, Package, Release, Documentation and Publish
 
-on: [ push ]
+on: 
+  push:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -76,38 +76,12 @@ jobs:
       pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
 
   BuildTheDocs:
-    name: 📓 Run BuildTheDocs
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
     needs:
+      - Params
       - VerifyDocs
-
-    env:
-      ARTIFACT: pyEDAA-ProjectModel-documentation
-    outputs:
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🚢 Build container image 'vhdl/doc'
-        run: |
-          docker build -t edaa/doc - <<-EOF
-          FROM btdi/sphinx:featured
-          RUN apk add -U --no-cache graphviz
-          EOF
-
-      - name: 🛳️ Build documentation using container edaa/doc
-        uses: buildthedocs/btd@v0
-        with:
-          skip-deploy: true
-
-      - name: 📤 Upload 'documentation' artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: doc/_build/html
-          retention-days: 7
+    with:
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
   PublishToGitHubPages:
     name: 📚 Publish to GH-Pages

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -18,7 +18,7 @@ jobs:
       - Params
     with:
       jobs: ${{ needs.Params.outputs.python_jobs }}
-      TestReport: true
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
     uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
@@ -36,7 +36,9 @@ jobs:
       - Params
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).package }}
+      commands: |
+        cd pyEDAA
+        mypy --html-report ../htmlmypy -p ProjectModel
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
@@ -55,7 +57,7 @@ jobs:
       - Coverage
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
@@ -66,7 +68,7 @@ jobs:
       - Package
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
@@ -109,10 +111,19 @@ jobs:
       - PublishToGitHubPages
 
     steps:
+
+      - name: 🗑️ Delete package Artifacts
+        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
       - name: 🗑️ Delete all Artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
             ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
             ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
             ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -84,54 +84,17 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
   PublishToGitHubPages:
-    name: 📚 Publish to GH-Pages
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
     needs:
+      - Params
       - BuildTheDocs
       - Coverage
       - StaticTypeCheck
+    with:
+      doc: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+      coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+      typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
-    env:
-      DOC:      ${{ needs.BuildTheDocs.outputs.artifact }}
-      COVERAGE: ${{ needs.Coverage.outputs.artifact }}
-      TYPING:   ${{ needs.StaticTypeCheck.outputs.artifact }}
-    outputs:
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 📥 Download artifacts '${{ env.DOC }}' from 'BuildTheDocs' job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.DOC }}
-          path: public
-
-      - name: 📥 Download artifacts '${{ env.COVERAGE }}' from 'Coverage' job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.COVERAGE }}
-          path: public/coverage
-
-      - name: 📥 Download artifacts '${{ env.TYPING }}' from 'StaticTypeCheck' job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.TYPING }}
-          path: public/typing
-
-      - name: '📓 Publish site to GitHub Pages'
-        if: github.event_name != 'pull_request'
-        run: |
-          cd public
-          touch .nojekyll
-          git init
-          cp ../.git/config ./.git/config
-          git add .
-          git config --local user.email "BuildTheDocs@GitHubActions"
-          git config --local user.name "GitHub Actions"
-          git commit -a -m "update ${{ github.sha }}"
-          git push -u origin +HEAD:gh-pages
 
   ArtifactCleanUp:
     name: 🗑️ Artifact Cleanup

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -38,57 +38,12 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
-    name: 📝 Create 'Release Page' on GitHub
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
       - Coverage
       - StaticTypeCheck
-
-    env:
-      PYTHON: ${{ needs.Coverage.outputs.python }}
-    outputs:
-      python:     ${{ env.PYTHON }}
-      tag:        ${{ steps.getVariables.outputs.gitTag }}
-      version:    ${{ steps.getVariables.outputs.version }}
-      datetime:   ${{ steps.getVariables.outputs.datetime }}
-      upload_url: ${{ steps.createReleasePage.outputs.upload_url }}
-
-    steps:
-      - name: 🔁 Extract Git tag from GITHUB_REF
-        id:   getVariables
-        run: |
-          GIT_TAG=${GITHUB_REF#refs/*/}
-          RELEASE_VERSION=${GIT_TAG#v}
-          RELEASE_DATETIME="$(date --utc '+%d.%m.%Y - %H:%M:%S')"
-          # write to step outputs
-          echo ::set-output name=gitTag::${GIT_TAG}
-          echo ::set-output name=version::${RELEASE_VERSION}
-          echo ::set-output name=datetime::${RELEASE_DATETIME}
-
-      - name: 📑 Create Release Page
-        id:   createReleasePage
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.getVariables.outputs.gitTag }}
-#          release_name: ${{ steps.getVariables.outputs.gitTag }}
-          body: |
-            **Automated Release created on: ${{ steps.getVariables.outputs.datetime }}**
-
-            # New Features
-            * tbd
-
-            # Changes
-            * tbd
-
-            # Bug Fixes
-            * tbd
-          draft: false
-          prerelease: false
 
   Package:
     name: 📦 Package in Wheel Format

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -7,13 +7,13 @@ on:
 jobs:
 
   Params:
-    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Params.yml@r0
     with:
       name: pyEDAA.ProjectModel
       python_version_list: '3.7 3.8 3.9 3.10'
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0
     needs:
       - Params
     with:
@@ -21,7 +21,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
-    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@r0
     needs:
       - Params
     with:
@@ -31,7 +31,7 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r0
     needs:
       - Params
     with:
@@ -42,7 +42,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Release.yml@r0
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
@@ -50,7 +50,7 @@ jobs:
       - StaticTypeCheck
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Package.yml@r0
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
@@ -60,7 +60,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r0
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
@@ -73,14 +73,14 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   VerifyDocs:
-    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev
+    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@r0
     needs:
       - Params
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
 
   BuildTheDocs:
-    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@r0
     needs:
       - Params
       - VerifyDocs
@@ -88,7 +88,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@r0
     needs:
       - Params
       - BuildTheDocs
@@ -100,7 +100,7 @@ jobs:
       typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r0
     needs:
       - Params
       - Coverage

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -103,6 +103,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r0
     needs:
       - Params
+      - UnitTesting
       - Coverage
       - StaticTypeCheck
       - BuildTheDocs

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -14,41 +14,7 @@ jobs:
       name: pyEDAA.ProjectModel
 
   UnitTesting:
-    name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-#          - {python: "3.6", icon: 🔴}  # until 23.12.2021
-          - {python: "3.7", icon: 🟠}  # until 27.06.2023
-          - {python: "3.8", icon: 🟡}  # until Oct. 2024
-          - {python: "3.9", icon: 🟢}  # until Oct. 2025
-          - {python: "3.10", icon: 🟢} # until Oct. 2026
-
-    env:
-      PYTHON: ${{ matrix.python }}
-    outputs:
-      python: ${{ env.PYTHON }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: 🔧 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
-
-      - name: ☑ Run unit tests
-        run: |
-          python -m pytest -rA tests/unit --color=yes
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
 
   Coverage:
     name: 📈 Collect Coverage Data using Python 3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -34,8 +34,8 @@ jobs:
     needs:
       - Params
     with:
-      package: ${{ fromJson(needs.Params.outputs.params).package }}
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).package }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -56,50 +56,17 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
-    name: 🚀 Publish to PyPI
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
+      - Params
       - Release
       - Package
-
-    env:
-      PYTHON:   ${{ needs.Package.outputs.python }}
-      ARTIFACT: ${{ needs.Package.outputs.artifact }}
-    outputs:
-      python:   ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: 📥 Download artifacts '${{ env.ARTIFACT }}' from 'Package' job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: dist/
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: ⚙ Install dependencies for packaging and release
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel twine
-
-      - name: ⤴ Release Python package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*
-
-      - name: 🗑️ Delete packaging Artifacts
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ env.ARTIFACT }}
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   VerifyDocs:
     name: 👍 Verify example snippets using Python 3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -69,53 +69,11 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   VerifyDocs:
-    name: 👍 Verify example snippets using Python 3.10
-    runs-on: ubuntu-latest
-
-    env:
-      PYTHON: "3.10"
-    outputs:
-      python: ${{ env.PYTHON }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🐍 Install dependencies
-        run: |
-          pip3 install .
-
-      - name: ✂ Extract code snippet from README
-        shell: python
-        run: |
-          from pathlib import Path
-          import re
-
-          ROOT = Path('.')
-
-          with (ROOT / 'README.md').open('r') as rptr:
-              content = rptr.read()
-
-          m = re.search(r"```py(thon)?(?P<code>.*?)```", content, re.MULTILINE|re.DOTALL)
-
-          if m is None:
-              raise Exception("Regular expression did not find the example in the README!")
-
-          with (ROOT / 'tests/docs/example.py').open('w') as wptr:
-              wptr.write(m["code"])
-
-      - name: Print example.py
-        run: cat tests/docs/example.py
-
-      - name: ☑ Run example snippet
-        working-directory: tests/docs
-        run: |
-          python3 example.py
+    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev
+    needs:
+      - Params
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
 
   BuildTheDocs:
     name: 📓 Run BuildTheDocs

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -41,6 +41,15 @@ jobs:
         mypy --html-report ../htmlmypy -p ProjectModel
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
+  Package:
+    uses: pyTooling/Actions/.github/workflows/Package.yml@r0
+    needs:
+      - Params
+      - Coverage
+    with:
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
   Release:
     uses: pyTooling/Actions/.github/workflows/Release.yml@r0
     if: startsWith(github.ref, 'refs/tags')
@@ -48,16 +57,7 @@ jobs:
       - UnitTesting
       - Coverage
       - StaticTypeCheck
-
-  Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@r0
-    if: startsWith(github.ref, 'refs/tags')
-    needs:
-      - Params
-      - Coverage
-    with:
-      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+      - Package
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r0

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -46,49 +46,14 @@ jobs:
       - StaticTypeCheck
 
   Package:
-    name: 📦 Package in Wheel Format
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
+      - Params
       - Coverage
-
-    env:
-      PYTHON:   ${{ needs.Coverage.outputs.python }}
-      ARTIFACT: pyEDAA-ProjectModel-wheel
-    outputs:
-      python:   ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🔧 Install dependencies for packaging and release
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel
-
-      - name: 🔨 Build Python package (source distribution)
-        run: |
-          python setup.py sdist
-
-      - name: 🔨 Build Python package (binary distribution - wheel)
-        run: |
-          python setup.py bdist_wheel
-
-      - name: 📤 Upload 'pyEDAA.ProjectModel' artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: dist/
-          if-no-files-found: error
-          retention-days: 1
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
     name: 🚀 Publish to PyPI

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -13,7 +13,10 @@ jobs:
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    needs:
+      - Params
     with:
+      jobs: ${{ needs.Params.outputs.python_jobs }}
       TestReport: true
 
   Coverage:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     needs:
       - Params
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
       - Params
     with:
       package: ${{ fromJson(needs.Params.outputs.params).package }}
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
@@ -50,7 +50,7 @@ jobs:
       - Params
       - Coverage
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
@@ -61,7 +61,7 @@ jobs:
       - Release
       - Package
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
     needs:
       - Params
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
 
   BuildTheDocs:
     uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -4,10 +4,6 @@ on:
   push:
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
 
   Params:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -8,6 +8,11 @@ defaults:
 
 jobs:
 
+  Params:
+    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    with:
+      name: pyEDAA.ProjectModel
+
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -99,31 +99,18 @@ jobs:
       coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
       typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
-
   ArtifactCleanUp:
-    name: 🗑️ Artifact Cleanup
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
     needs:
       - Params
       - Coverage
       - StaticTypeCheck
       - BuildTheDocs
       - PublishToGitHubPages
-
-    steps:
-
-      - name: 🗑️ Delete package Artifacts
-        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
-
-      - name: 🗑️ Delete all Artifacts
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
-            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
-            ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
-            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+    with:
+      package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+      remaining: |
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
+        ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -15,7 +15,9 @@ jobs:
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
-
+    with:
+      TestReport: true
+      
   Coverage:
     name: 📈 Collect Coverage Data using Python 3.10
     runs-on: ubuntu-latest

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -100,21 +100,17 @@ jobs:
     name: 🗑️ Artifact Cleanup
     runs-on: ubuntu-latest
     needs:
+      - Params
       - Coverage
       - StaticTypeCheck
       - BuildTheDocs
       - PublishToGitHubPages
-
-    env:
-      COVERAGE: ${{ needs.Coverage.outputs.artifact }}
-      TYPING:   ${{ needs.StaticTypeCheck.outputs.artifact }}
-      DOC:      ${{ needs.BuildTheDocs.outputs.artifact }}
 
     steps:
       - name: 🗑️ Delete all Artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
-            ${{ env.COVERAGE }}
-            ${{ env.TYPING }}
-            ${{ env.DOC }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -10,6 +10,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Params.yml@dev
     with:
       name: pyEDAA.ProjectModel
+      python_version_list: '3.7 3.8 3.9 3.10'
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pydecor>=2.0.1
 
 pyVHDLModel>=0.13.2
-pySVModel>=0.3.0
+pySVModel>=0.3.1


### PR DESCRIPTION
In this PR, the CI Pipeline is reworked in order to use reusable workflows from pyTooling/Actions (see pyTooling/Actions#1).

Each job is replaced with a call to a reusable workflow. 

As explained in VHDL/pyVHDLModel#36, the logic for dealing with global parameters is changed.

MPORTANT: reusable workflows must be used through an absolute name and specifying a version (see actions/runner#1493). Therefore, this PR will be kept as a draft, because s/@dev/@main/ is required in Pipeline.yml before merging.