### PR TITLE
doc: add placeholder text for coverage and typing reports

### DIFF
--- a/doc/coverage/index.rst
+++ b/doc/coverage/index.rst
@@ -1,2 +1,4 @@
 Coverage Report
 ###############
+
+*Placeholder for the Coverage report generated with* ``pytest`` *and* ``coverage``.

--- a/doc/typing/index.rst
+++ b/doc/typing/index.rst
@@ -1,2 +1,4 @@
 Static Type Checking Report
 ###########################
+
+*Placeholder for the Static Type Checking report generated with* ``mypy``.


### PR DESCRIPTION
If there is some failure in CI and coverage or typing report artifacts are not properly added, the site will show empty pages in those sections. This PR adds some placeholder text, so that visitors can find an explanation instead of a white page.